### PR TITLE
macOS support

### DIFF
--- a/src/pypci/__main__.py
+++ b/src/pypci/__main__.py
@@ -5,8 +5,8 @@ import sys
 
 
 def main():
-    if getOS() not in ["linux", "windows", "freebsd"]:
-        print(f"Only Linux, Windows, and FreeBSD are supported for now. Current OS: {getOS()}")
+    if getOS() not in ["linux", "windows", "freebsd", "macos"]:
+        print(f"Only Linux, Windows, FreeBSD, and macOS are supported for now. Current OS: {getOS()}")
         return
     if len(sys.argv) == 2:
         if sys.argv[1] == "-d" or sys.argv[1] == "--list-drivers":


### PR DESCRIPTION
Add macOS support
This PR adds native macOS support to pypci-ng, enabling the library to enumerate PCI/PCIe devices on macOS systems using the IORegistry framework.